### PR TITLE
No longer need implode

### DIFF
--- a/core/class/remora.class.php
+++ b/core/class/remora.class.php
@@ -48,7 +48,7 @@ class remora extends eqLogic {
       $devAddr = 'http://' . $addr . '/tinfo';
       $devRequest = new com_http($devAddr);
       $devResult = $devRequest->exec();
-      $ticall =implode($devResult);
+      $ticall = $devResult;
     } else {
       $accessToken = config::byKey('token', 'remora', 0);
       $deviceid = config::byKey('deviceid', 'remora', 0);
@@ -66,7 +66,7 @@ class remora extends eqLogic {
     }
 
       $tinfo = json_decode($ticall);
-      //log::add('remora', 'debug', 'Retour ' . print_r($tinfo,true));
+      log::add('remora', 'debug', 'Retour Teleinfo ' . print_r($tinfo,true));
       foreach($tinfo as $key => $value ) {
         log::add('remora', 'debug', 'Retour Teleinfo ' . $key . ' valeur ' . $value);
         $remora = self::byLogicalId('teleinfo', 'remora');


### PR DESCRIPTION
Je n'utilisais pas la récupération de la téléinfo via le plugin remora mais via le plugin téléinfo en Push, donc j'avais zappé ce problème :(.
J'ai vu dans mes logs cron_execution un problème sur le plugin.
```
PHP Warning:  implode(): Argument must be an array in /var/www/html/plugins/remora/core/class/remora.class.php on line 52
PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/plugins/remora/core/class/remora.class.php on line 71
```
En utilisant la classe `com_http` le json renvoyé par /tinfo n'est plus un tableau ??? J'ai testé en enlevant le `implode()` en version 1.3.2 -> 1.3.5 et c'est OK